### PR TITLE
Filter descriptions allows regex without limitations

### DIFF
--- a/src/modules/Giveaways/EnterLeaveGiveawayButton.jsx
+++ b/src/modules/Giveaways/EnterLeaveGiveawayButton.jsx
@@ -691,7 +691,7 @@ class GiveawaysEnterLeaveGiveawayButton extends Module {
 	}
 
 	processFilters(filters) {
-		return filters.replace(/(^|\|)\.*(\*|\+)\.*($|\|)/g, '').replace(/\|$/, '');
+		return filters;
 	}
 
 	async elgb_enterGiveaway(giveaway, main, popup, source, callback) {


### PR DESCRIPTION
2.11.3 Filter descriptions allows regex without limitations. You can use `.*` to filter all descriptions, therefore not displaying the description when using enter button.